### PR TITLE
Upgraded to latest version of Spring Boot. Also updated spring boot m…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- check these for changes and compatibility when upgrading Spring Boot -->
         <commons-logging.version>1.2</commons-logging.version>
-        <springboot.version>1.3.3.RELEASE</springboot.version>
+        <springboot.version>1.5.2.RELEASE</springboot.version>
     </properties>
 
     <dependencyManagement>
@@ -65,6 +65,12 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                	<!-- Does not bundle a bootstrap loader. (e.g. classes and libs are not loaded into a BOOT-INF directory
+                	Pre version 1.4.0.RELEASE of Spring Boot - this was default but if you do not specify this layout for version 1.4.0.RELEASE
+                	going forward - you will get a class not found exception when trying to invoke a handler from Amazon Lambda -->
+					<layout>MODULE</layout>
+				</configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Upgraded to latest version of Spring Boot. Also updated spring boot maven plugin to work correctly in Lambda after upgrading the version of Spring Boot.
Pre version 1.4.0.RELEASE of Spring Boot - all classes and jars are deployed like a standard jar file
From version 1.4.0.RELEASE and on - the classes and jars are deployed in a BOOT-INF directory which cannot be read by Amazon Lambda and results in class not found exceptions